### PR TITLE
Adds `moveit_simple_controller_manager` as a dependency of `franka_moveit_config`

### DIFF
--- a/franka_moveit_config/package.xml
+++ b/franka_moveit_config/package.xml
@@ -29,6 +29,7 @@
   <exec_depend>gazebo_plugins</exec_depend>
   <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>ros2_control</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Without `moveit_simple_controller_manager` the following error shows up:
```
[move_group-3] [FATAL] [moveit_ros.trajectory_execution_manager]: Exception while loading controller manager 'moveit_simple_controller_manager/MoveItSimpleControllerManager': According to the loaded plugin descriptions the class moveit_simple_controller_manager/MoveItSimpleControllerManager with base class type moveit_controller_manager::MoveItControllerManager does not exist. Declared types are 
[move_group-3] [ERROR] [moveit_ros.trajectory_execution_manager]: Failed to reload controllers: `controller_manager_` does not exist.
```

This PR adds `moveit_simple_controller_manager` as an `exec_depend` of `franka_moveit_config`.